### PR TITLE
Add clear icon on Notification

### DIFF
--- a/library/src/main/AndroidManifest.xml
+++ b/library/src/main/AndroidManifest.xml
@@ -30,5 +30,6 @@
         <activity android:name=".internal.ui.TransactionActivity"
             android:theme="@style/Chuck.Theme"
             android:parentActivityName=".internal.ui.MainActivity"/>
+        <service android:name=".internal.ClearService" android:exported="false" />
     </application>
 </manifest>

--- a/library/src/main/java/com/readystatesoftware/chuck/internal/ClearService.java
+++ b/library/src/main/java/com/readystatesoftware/chuck/internal/ClearService.java
@@ -1,0 +1,22 @@
+package com.readystatesoftware.chuck.internal;
+
+import android.app.IntentService;
+import android.content.Intent;
+import android.support.annotation.Nullable;
+import com.readystatesoftware.chuck.internal.data.ChuckContentProvider;
+import com.readystatesoftware.chuck.internal.support.NotificationHelper;
+
+public class ClearService extends IntentService {
+
+  public ClearService() {
+    super("ClearService");
+  }
+
+  @Override
+  protected void onHandleIntent(@Nullable Intent intent) {
+    getContentResolver().delete(ChuckContentProvider.TRANSACTION_URI, null, null);
+    NotificationHelper.clearBuffer();
+    NotificationHelper notificationHelper = new NotificationHelper(this);
+    notificationHelper.dismiss();
+  }
+}

--- a/library/src/main/java/com/readystatesoftware/chuck/internal/support/NotificationHelper.java
+++ b/library/src/main/java/com/readystatesoftware/chuck/internal/support/NotificationHelper.java
@@ -18,12 +18,14 @@ package com.readystatesoftware.chuck.internal.support;
 import android.app.NotificationManager;
 import android.app.PendingIntent;
 import android.content.Context;
+import android.content.Intent;
 import android.os.Build;
+import android.support.annotation.NonNull;
 import android.support.v4.app.NotificationCompat;
 import android.util.LongSparseArray;
-
 import com.readystatesoftware.chuck.Chuck;
 import com.readystatesoftware.chuck.R;
+import com.readystatesoftware.chuck.internal.ClearService;
 import com.readystatesoftware.chuck.internal.data.HttpTransaction;
 import com.readystatesoftware.chuck.internal.ui.BaseChuckActivity;
 
@@ -85,8 +87,18 @@ public class NotificationHelper {
             } else {
                 mBuilder.setNumber(transactionCount);
             }
+            mBuilder.addAction(getClearAction());
             notificationManager.notify(NOTIFICATION_ID, mBuilder.build());
         }
+    }
+
+    @NonNull
+    private NotificationCompat.Action getClearAction() {
+        CharSequence clearTitle = context.getString(R.string.chuck_clear);
+        Intent deleteIntent = new Intent(context, ClearService.class);
+        PendingIntent intent = PendingIntent.getService(context, 11, deleteIntent, PendingIntent.FLAG_ONE_SHOT);
+        return new NotificationCompat.Action(R.drawable.chuck_ic_delete_white_24dp,
+            clearTitle, intent);
     }
 
     public void dismiss() {


### PR DESCRIPTION
This PR add a `clear` action into notification, so it's easy to delete all the content and dismiss the notification itself.

It helps to debug apps, so developer can clean the stack without leaving app.