### PR TITLE
Lower minSdk requirement to API 11

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,7 +26,7 @@ task clean(type: Delete) {
 }
 
 ext {
-    minSdkVersion = 16
+    minSdkVersion = 11
     targetSdkVersion = 25
     compileSdkVersion = 25
     buildToolsVersion = '25.0.2'

--- a/library-no-op/build.gradle
+++ b/library-no-op/build.gradle
@@ -8,6 +8,10 @@ android {
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
     }
+
+    lintOptions {
+        disable "InvalidPackage"
+    }
 }
 
 dependencies {

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -9,6 +9,10 @@ android {
         targetSdkVersion rootProject.ext.targetSdkVersion
         consumerProguardFiles 'proguard-rules.pro'
     }
+
+    lintOptions {
+        disable "InvalidPackage"
+    }
 }
 
 dependencies {

--- a/library/src/main/java/com/readystatesoftware/chuck/internal/support/NotificationHelper.java
+++ b/library/src/main/java/com/readystatesoftware/chuck/internal/support/NotificationHelper.java
@@ -22,7 +22,7 @@ import android.content.Intent;
 import android.os.Build;
 import android.support.annotation.NonNull;
 import android.support.v4.app.NotificationCompat;
-import android.util.LongSparseArray;
+import android.support.v4.util.LongSparseArray;
 
 import com.readystatesoftware.chuck.Chuck;
 import com.readystatesoftware.chuck.R;

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -22,6 +22,10 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
     }
+
+    lintOptions {
+        disable "InvalidPackage"
+    }
 }
 
 dependencies {


### PR DESCRIPTION
The only occurence of an API available only from Android 4.1 onward in this project comes from the reference of `android.util.LongSparseArray` inside `NotificationHelper`. Since you're pulling in & using support-v4 anyway, it is a very low-maintenance effort to reduce the minSdk requirement down to API 11 by using `android.support.v4.util.LongSparseArray`.

Also, I disabled the lint check which trips over Okio's reference to Java NIO.

(I haven't checked if it could go down *even lower* than that, but I guess we need to draw the line somewhere.)