### PR TITLE
Add the ability to add an app shortcut to open chuck from the launcher icon

### DIFF
--- a/library-no-op/src/main/java/com/readystatesoftware/chuck/Chuck.java
+++ b/library-no-op/src/main/java/com/readystatesoftware/chuck/Chuck.java
@@ -15,8 +15,10 @@
  */
 package com.readystatesoftware.chuck;
 
+import android.annotation.TargetApi;
 import android.content.Context;
 import android.content.Intent;
+import android.os.Build;
 
 /**
  * No-op implementation.
@@ -25,5 +27,11 @@ public class Chuck {
 
     public static Intent getLaunchIntent(Context context) {
         return new Intent();
+    }
+
+    @TargetApi(Build.VERSION_CODES.N_MR1)
+    @SuppressWarnings("WeakerAccess")
+    public static String addAppShortcut(Context context) {
+        return null;
     }
 }

--- a/library/src/main/java/com/readystatesoftware/chuck/Chuck.java
+++ b/library/src/main/java/com/readystatesoftware/chuck/Chuck.java
@@ -15,10 +15,16 @@
  */
 package com.readystatesoftware.chuck;
 
+import android.annotation.TargetApi;
 import android.content.Context;
 import android.content.Intent;
-
+import android.content.pm.ShortcutInfo;
+import android.content.pm.ShortcutManager;
+import android.graphics.drawable.Icon;
+import android.os.Build;
+import android.support.annotation.Nullable;
 import com.readystatesoftware.chuck.internal.ui.MainActivity;
+import java.util.Collections;
 
 /**
  * Chuck utilities.
@@ -33,5 +39,31 @@ public class Chuck {
      */
     public static Intent getLaunchIntent(Context context) {
         return new Intent(context, MainActivity.class).setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+    }
+
+    /**
+     * Register an app shortcut to launch the Chuck UI directly from the launcher on Android 7.0 and above.
+     *
+     * @param context A valid {@link Context}
+     * @return The id of the added shortcut (<code>null</code> if this feature is not supported on the device).
+     * It can be used if you want to remove this shortcut later on.
+     */
+    @TargetApi(Build.VERSION_CODES.N_MR1)
+    @SuppressWarnings("WeakerAccess")
+    @Nullable
+    public static String addAppShortcut(Context context) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N_MR1) {
+            final String id = context.getPackageName() + ".chuck_ui";
+            final ShortcutManager shortcutManager = context.getSystemService(ShortcutManager.class);
+            final ShortcutInfo shortcut = new ShortcutInfo.Builder(context, id).setShortLabel("Chuck")
+                .setLongLabel("Open Chuck UI")
+                .setIcon(Icon.createWithResource(context, R.drawable.chuck_ic_notification_white_24dp))
+                .setIntent(getLaunchIntent(context).setAction(Intent.ACTION_VIEW))
+                .build();
+            shortcutManager.addDynamicShortcuts(Collections.singletonList(shortcut));
+            return id;
+        } else {
+            return null;
+        }
     }
 }

--- a/sample/src/main/java/com/readystatesoftware/chuck/sample/MainActivity.java
+++ b/sample/src/main/java/com/readystatesoftware/chuck/sample/MainActivity.java
@@ -48,6 +48,7 @@ public class MainActivity extends AppCompatActivity {
                 launchChuckDirectly();
             }
         });
+        Chuck.addAppShortcut(this);
     }
 
     private OkHttpClient getClient(Context context) {


### PR DESCRIPTION
This commit adds the ability to add an app shortcut to the clients' launcher icon on android devices running android 7.0 and above. With that app shortcut the Chuck UI can be accessed. This can be useful if no notification is desired but there still need to be a simple way to enter chuck.