### PR TITLE
Update usage to 'implementation' rather than 'compile' in gradle example

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,8 @@ Add the dependency in your `build.gradle` file. Add it alongside the `no-op` var
 
 ```gradle
  dependencies {
-   debugCompile 'com.readystatesoftware.chuck:library:1.1.0'
-   releaseCompile 'com.readystatesoftware.chuck:library-no-op:1.1.0'
+   debugImplementation 'com.readystatesoftware.chuck:library:1.1.0'
+   releaseImplementation 'com.readystatesoftware.chuck:library-no-op:1.1.0'
  }
 ```
 


### PR DESCRIPTION
The Readme is currently using the old `compile` configuration to add Chuck as a dependency.
Probably makes sense to update to `implementation`.